### PR TITLE
default.py: restore old copyright notice

### DIFF
--- a/default.py
+++ b/default.py
@@ -4,6 +4,27 @@
 # This plugin is modelled over the now defunct TVKaista plugin. 
 # Ackownledgements goes to Viljo Viitanen,sampov2,stilester,& J. Luukko
 #
+# Copyright (C) 2015       Aslak Grinsted
+# Copyright (C) 2009-2014  Viljo Viitanen <viljo.viitanen@iki.fi>
+# Copyright (C) 2014       grinsted
+# Copyright (C) 2014       sampov2
+# Copyright (C) 2010       stilester
+# Copyright (C) 2008-2009  J. Luukko
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.#
+#
 # change history:
 #
 #


### PR DESCRIPTION
Restore the license notice and copyright statements from old tvkaista plugin, requirement of the gnu gpl.
